### PR TITLE
IOPS-1870 Allow Van as surname when only surname

### DIFF
--- a/src/Mapper/LastnameMapper.php
+++ b/src/Mapper/LastnameMapper.php
@@ -58,7 +58,9 @@ class LastnameMapper extends AbstractMapper
 
             if ($this->isFollowedByLastnamePart($originalParts, $originalIndex)) {
                 if ($this->isApplicablePrefix($originalParts, $originalIndex)) {
-                    $parts[$k] = new Lastname($part);
+                    $lastname = new Lastname($part);
+                    $lastname->setApplyPrefix(true);
+                    $parts[$k] = $lastname;
                     continue;
                 }
                 break;

--- a/src/Part/Lastname.php
+++ b/src/Part/Lastname.php
@@ -24,6 +24,8 @@ class Lastname extends AbstractPart
         'la' => 'la',
         'ter' => 'ter'
     ];
+    /** @var bool */
+    private $applyPrefix = false;
 
     /**
      * check if the given word is a lastname prefix
@@ -57,10 +59,18 @@ class Lastname extends AbstractPart
     {
         $value = $this->getValue();
 
-        if (self::isPrefix($value)) {
+        if ($this->applyPrefix && self::isPrefix($value)) {
             return static::$prefixes[self::getKey($value)];
         }
 
         return $this->camelcase($this->getValue());
+    }
+
+    /**
+     * @param bool $applyPrefix
+     */
+    public function setApplyPrefix(bool $applyPrefix)
+    {
+        $this->applyPrefix = $applyPrefix;
     }
 }

--- a/tests/Mapper/LastnameMapperTest.php
+++ b/tests/Mapper/LastnameMapperTest.php
@@ -13,6 +13,9 @@ class LastnameMapperTest extends AbstractMapperTest
      */
     public function provider()
     {
+        $vanPrefix = new Lastname('van');
+        $vanPrefix->setApplyPrefix(true);
+
         return [
             [
                 'input' => [
@@ -58,7 +61,7 @@ class LastnameMapperTest extends AbstractMapperTest
                 'expectation' => [
                     new Salutation('Mr'),
                     'Lars',
-                    new Lastname('van'),
+                    $vanPrefix,
                     new Lastname('Trier'),
                 ],
             ],

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -320,6 +320,13 @@ class ParserTest extends TestCase
                 ],
             ],
             [
+                'John Van',
+                [
+                    'firstname' => 'John',
+                    'lastname' => 'Van',
+                ],
+            ],
+            [
                 'Mr. Van Truong',
                 [
                     'salutation' => 'Mr.',


### PR DESCRIPTION
It was detected that Van was always detected as prefix of surname.
However, it did not make sense to have a prefix without a surname.
This PR fixes that, it checks if it is the only surname and if it
is, it get the only surname as surname without paying attention
to the prefixes.