### PR TITLE
Support single letter surname

### DIFF
--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -366,6 +366,13 @@ class ParserTest extends TestCase
                     'lastname' => 'Kirk',
                 ],
             ],
+            [
+                'James B',
+                [
+                    'firstname' => 'James',
+                    'lastname' => 'B',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Hi there,

Will this package support surnames with only a single letter? We regularly see people using a single letter for their last name for more anonymity. Also some Japanese surnames contain only a single letter.

This PR will demonstrate the lastname will be parsed as an initial.