### PR TITLE
Automatic title case conversion honors now unicode characters

### DIFF
--- a/src/Part/AbstractPart.php
+++ b/src/Part/AbstractPart.php
@@ -81,6 +81,10 @@ abstract class AbstractPart
      */
     protected function camelcaseReplace($matches): string
     {
-        return mb_convert_case($matches[0], MB_CASE_TITLE, "UTF-8");
+        if (function_exists('mb_convert_case')) {
+            return mb_convert_case($matches[0], MB_CASE_TITLE, "UTF-8");
+        }
+        
+        return ucfirst(strtolower($matches[0]));
     }
 }

--- a/src/Part/AbstractPart.php
+++ b/src/Part/AbstractPart.php
@@ -66,11 +66,11 @@ abstract class AbstractPart
      */
     protected function camelcase($word): string
     {
-        if (preg_match('/[A-Za-z]([A-Z]*[a-z][a-z]*[A-Z]|[a-z]*[A-Z][A-Z]*[a-z])[A-Za-z]*/', $word)) {
+        if (preg_match('/\p{L}(\p{Lu}*\p{Ll}\p{Ll}*\p{Lu}|\p{Ll}*\p{Lu}\p{Lu}*\p{Ll})\p{L}*/u', $word)) {
             return $word;
         }
 
-        return preg_replace_callback('/[a-z0-9]+/i', [$this, 'camelcaseReplace'], $word);
+        return preg_replace_callback('/[\p{L}0-9]+/ui', [$this, 'camelcaseReplace'], $word);
     }
 
     /**
@@ -81,6 +81,6 @@ abstract class AbstractPart
      */
     protected function camelcaseReplace($matches): string
     {
-        return ucfirst(strtolower($matches[0]));
+        return mb_convert_case($matches[0], MB_CASE_TITLE, "UTF-8");
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -400,6 +400,20 @@ class ParserTest extends TestCase
                     'lastname' => 'Getty',
                     'suffix' => 'Sr',
                 ]
+            ],
+            [
+                'etna übel',
+                [
+                    'firstname' => 'Etna',
+                    'lastname' => 'Übel',
+                ]
+            ],
+            [
+                'Markus Müller',
+                [
+                    'firstname' => 'Markus',
+                    'lastname' => 'Müller',
+                ]
             ]
         ];
     }


### PR DESCRIPTION
- Changed regex to honor unicode characters for title case matching
- Changed title case conversion to mb_convert_case with utf-8