### PR TITLE
Enable lastname remapping - fixes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ $parser = new TheIconic\NameParser\Parser();
 $parser->setWhitespace("\t _.");
 ```
 
+### Limiting the position of salutations
+```php
+$parser = new TheIconic\NameParser\Parser();
+$parser->setMaxSalutationIndex(2);
+```
+This will require salutations to appear within the
+first two words of the given input string.
+This defaults to half the amount of words in the input string,
+meaning that effectively the salutation may occur within
+the first half of the name parts.
+
 ## License
 
 THE ICONIC Name Parser library for PHP is released under the MIT License.

--- a/src/Mapper/SalutationMapper.php
+++ b/src/Mapper/SalutationMapper.php
@@ -9,9 +9,12 @@ class SalutationMapper extends AbstractMapper
 {
     protected $salutations = [];
 
-    public function __construct(array $salutations)
+    protected $maxIndex = 0;
+
+    public function __construct(array $salutations, $maxIndex = 0)
     {
         $this->salutations = $salutations;
+        $this->maxIndex = $maxIndex;
     }
 
     /**
@@ -22,7 +25,11 @@ class SalutationMapper extends AbstractMapper
      */
     public function map(array $parts): array
     {
-        foreach ($parts as $k => $part) {
+        $max = ($this->maxIndex > 0) ? $this->maxIndex : floor(count($parts) / 2);
+
+        for ($k = 0; $k < $max; $k++) {
+            $part = $parts[$k];
+
             if ($part instanceof AbstractPart) {
                 break;
             }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -33,6 +33,11 @@ class Parser
      */
     protected $nicknameDelimiters = [];
 
+    /**
+     * @var int
+     */
+    protected $maxSalutationIndex = 0;
+
     public function __construct(array $languages = [])
     {
         if (empty($languages)) {
@@ -99,7 +104,7 @@ class Parser
         $parser = new Parser();
 
         $parser->setMappers([
-            new SalutationMapper($this->getSalutations()),
+            new SalutationMapper($this->getSalutations(), $this->getMaxSalutationIndex()),
             new SuffixMapper($this->getSuffixes()),
             new LastnameMapper($this->getPrefixes(), true),
             new FirstnameMapper(),
@@ -117,7 +122,7 @@ class Parser
         $parser = new Parser();
 
         $parser->setMappers([
-            new SalutationMapper($this->getSalutations()),
+            new SalutationMapper($this->getSalutations(), $this->getMaxSalutationIndex()),
             new SuffixMapper($this->getSuffixes(), true),
             new NicknameMapper($this->getNicknameDelimiters()),
             new InitialMapper(true),
@@ -149,7 +154,7 @@ class Parser
         if (empty($this->mappers)) {
             $this->setMappers([
                 new NicknameMapper($this->getNicknameDelimiters()),
-                new SalutationMapper($this->getSalutations()),
+                new SalutationMapper($this->getSalutations(), $this->getMaxSalutationIndex()),
                 new SuffixMapper($this->getSuffixes()),
                 new InitialMapper(),
                 new LastnameMapper($this->getPrefixes()),
@@ -272,6 +277,25 @@ class Parser
     public function setNicknameDelimiters(array $nicknameDelimiters): Parser
     {
         $this->nicknameDelimiters = $nicknameDelimiters;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxSalutationIndex(): int
+    {
+        return $this->maxSalutationIndex;
+    }
+
+    /**
+     * @param int $maxSalutationIndex
+     * @return Parser
+     */
+    public function setMaxSalutationIndex(int $maxSalutationIndex): Parser
+    {
+        $this->maxSalutationIndex = $maxSalutationIndex;
 
         return $this;
     }

--- a/tests/Mapper/FirstnameMapperTest.php
+++ b/tests/Mapper/FirstnameMapperTest.php
@@ -48,6 +48,16 @@ class FirstnameMapperTest extends AbstractMapperTest
                     new Lastname('Pan'),
                 ],
             ],
+            [
+                'input' => [
+                    'Alfonso',
+                    new Salutation('Mr'),
+                ],
+                'expectation' => [
+                    new Firstname('Alfonso'),
+                    new Salutation('Mr'),
+                ]
+            ]
         ];
     }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -434,10 +434,24 @@ class ParserTest extends TestCase
             [
                 'PAUL M LEWIS MR',
                 [
-                    'salutation' => 'Mr.',
                     'firstname' => 'Paul',
                     'initials' => 'M',
-                    'lastname' => 'Lewis',
+                    'lastname' => 'Lewis Mr',
+                ]
+            ],
+            [
+                'SUJAN MASTER',
+                [
+                    'firstname' => 'Sujan',
+                    'lastname' => 'Master',
+                ],
+            ],
+            [
+                'JAMES J MA',
+                [
+                    'firstname' => 'James',
+                    'initials' => 'J',
+                    'lastname' => 'Ma'
                 ]
             ]
         ];
@@ -493,5 +507,20 @@ class ParserTest extends TestCase
         $this->assertSame(['[' => ']'], $parser->getNicknameDelimiters());
         $this->assertSame('Jim', $parser->parse('[Jim]')->getNickname());
         $this->assertNotSame('Jim', $parser->parse('(Jim)')->getNickname());
+    }
+
+    public function testSetMaxSalutationIndex()
+    {
+        $parser = new Parser();
+        $this->assertSame(0, $parser->getMaxSalutationIndex());
+        $parser->setMaxSalutationIndex(1);
+        $this->assertSame(1, $parser->getMaxSalutationIndex());
+        $this->assertSame('', $parser->parse('Francis Mr')->getSalutation());
+
+        $parser = new Parser();
+        $this->assertSame(0, $parser->getMaxSalutationIndex());
+        $parser->setMaxSalutationIndex(2);
+        $this->assertSame(2, $parser->getMaxSalutationIndex());
+        $this->assertSame('Mr.', $parser->parse('Francis Mr')->getSalutation());
     }
 }


### PR DESCRIPTION
Names like "SUJAN MASTER", "JAMES J MA", "PETER K MA" had the 'Master'
or 'Ma' parts as special parts (salutations, suffixes) where they
should be lastnames. In "PAUL M LEWIS MR", the lastname should be
'Lewis Mr'.

This change does three things to fix this:
Firstly, it prevents parsing for salutations beyond the first half of words in
the given string. It also introduces a `setMaxSalutationIndex()` method
to allow overriding this with a fixed maximum word index. E.g. setting
it to 2 will require salutations to appear in the first two words.

Secondly, if the lastname mapper does not derive a lastname, but has skipped
ignored parts like suffix, nickname or salutation, it will convert these into
lastname parts.

Thirdly, the lastname mapper will now map more than one lastname part if
the already mapped lastname parts are shorter than 3 characters and there
will be at least one part left after mapping. This effectively maps
'Lewis' in 'Paul M Lewis Mr' as lastname instead of previously as middlename.