### PR TITLE
Enable suffixes in second name segment

### DIFF
--- a/src/Mapper/SuffixMapper.php
+++ b/src/Mapper/SuffixMapper.php
@@ -11,10 +11,13 @@ class SuffixMapper extends AbstractMapper
 
     protected $matchSinglePart = false;
 
-    public function __construct(array $suffixes, bool $matchSinglePart = false)
+    protected $reservedParts = 2;
+
+    public function __construct(array $suffixes, bool $matchSinglePart = false, int $reservedParts = 2)
     {
         $this->suffixes = $suffixes;
         $this->matchSinglePart = $matchSinglePart;
+        $this->reservedParts = $reservedParts;
     }
 
     /**
@@ -32,7 +35,7 @@ class SuffixMapper extends AbstractMapper
 
         $start = count($parts) - 1;
 
-        for ($k = $start; $k > 1; $k--) {
+        for ($k = $start; $k > $this->reservedParts - 1; $k--) {
             $part = $parts[$k];
 
             if (!$this->isSuffix($part)) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -105,7 +105,7 @@ class Parser
 
         $parser->setMappers([
             new SalutationMapper($this->getSalutations(), $this->getMaxSalutationIndex()),
-            new SuffixMapper($this->getSuffixes()),
+            new SuffixMapper($this->getSuffixes(), false, 2),
             new LastnameMapper($this->getPrefixes(), true),
             new FirstnameMapper(),
             new MiddlenameMapper(),
@@ -123,7 +123,7 @@ class Parser
 
         $parser->setMappers([
             new SalutationMapper($this->getSalutations(), $this->getMaxSalutationIndex()),
-            new SuffixMapper($this->getSuffixes(), true),
+            new SuffixMapper($this->getSuffixes(), true, 1),
             new NicknameMapper($this->getNicknameDelimiters()),
             new InitialMapper(true),
             new FirstnameMapper(),
@@ -138,7 +138,7 @@ class Parser
         $parser = new Parser();
 
         $parser->setMappers([
-            new SuffixMapper($this->getSuffixes(), true),
+            new SuffixMapper($this->getSuffixes(), true, 0),
         ]);
 
         return $parser;

--- a/tests/Mapper/SuffixMapperTest.php
+++ b/tests/Mapper/SuffixMapperTest.php
@@ -28,6 +28,10 @@ class SuffixMapperTest extends AbstractMapperTest
                     'Blueberg',
                     new Suffix('PhD'),
                 ],
+                [
+                    'matchSinglePart' => false,
+                    'reservedParts' => 2,
+                ]
             ],
             [
                 'input' => [
@@ -40,6 +44,10 @@ class SuffixMapperTest extends AbstractMapperTest
                     'Alfred',
                     new Suffix('III'),
                 ],
+                [
+                    'matchSinglePart' => false,
+                    'reservedParts' => 2,
+                ]
             ],
             [
                 'input' => [
@@ -52,6 +60,10 @@ class SuffixMapperTest extends AbstractMapperTest
                     new Lastname('Smith'),
                     new Suffix('Senior'),
                 ],
+                [
+                    'matchSinglePart' => false,
+                    'reservedParts' => 2,
+                ]
             ],
             [
                 'input' => [
@@ -64,6 +76,10 @@ class SuffixMapperTest extends AbstractMapperTest
                     new Firstname('James'),
                     'Norrington',
                 ],
+                [
+                    'matchSinglePart' => false,
+                    'reservedParts' => 2,
+                ]
             ],
             [
                 'input' => [
@@ -76,14 +92,73 @@ class SuffixMapperTest extends AbstractMapperTest
                     new Firstname('James'),
                     new Lastname('Norrington'),
                 ],
+                [
+                    'matchSinglePart' => false,
+                    'reservedParts' => 2,
+                ]
+            ],
+            [
+                'input' => [
+                    'James',
+                    'Norrington',
+                    'Senior',
+                ],
+                'expectation' => [
+                    'James',
+                    'Norrington',
+                    new Suffix('Senior'),
+                ],
+                [
+                    false,
+                    2,
+                ]
+            ],
+            [
+                'input' => [
+                    'Norrington',
+                    'Senior',
+                ],
+                'expectation' => [
+                    'Norrington',
+                    'Senior',
+                ],
+                [
+                    false,
+                    2,
+                ]
+            ],
+            [
+                'input' => [
+                    new Lastname('Norrington'),
+                    'Senior',
+                ],
+                'expectation' => [
+                    new Lastname('Norrington'),
+                    new Suffix('Senior'),
+                ],
+                [
+                    false,
+                    1,
+                ]
+            ],
+            [
+                'input' => [
+                    'Senior',
+                ],
+                'expectation' => [
+                    new Suffix('Senior'),
+                ],
+                [
+                    true,
+                ]
             ],
         ];
     }
 
-    protected function getMapper()
+    protected function getMapper($matchSinglePart = false, $reservedParts = 2)
     {
         $english = new English();
 
-        return new SuffixMapper($english->getSuffixes());
+        return new SuffixMapper($english->getSuffixes(), $matchSinglePart, $reservedParts);
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -451,7 +451,41 @@ class ParserTest extends TestCase
                 [
                     'firstname' => 'James',
                     'initials' => 'J',
-                    'lastname' => 'Ma'
+                    'lastname' => 'Ma',
+                ]
+            ],
+            [
+                'Tiptree, James, Jr.',
+                [
+                    'lastname' => 'Tiptree',
+                    'firstname' => 'James',
+                    'suffix' => 'Jr',
+                ]
+            ],
+            [
+                'Miller, Walter M., Jr.',
+                [
+                    'lastname' => 'Miller',
+                    'firstname' => 'Walter',
+                    'initials' => 'M.',
+                    'suffix' => 'Jr',
+                ]
+            ],
+            [
+                'Tiptree, James Jr.',
+                [
+                    'lastname' => 'Tiptree',
+                    'firstname' => 'James',
+                    'suffix' => 'Jr',
+                ]
+            ],
+            [
+                'Miller, Walter M. Jr.',
+                [
+                    'lastname' => 'Miller',
+                    'firstname' => 'Walter',
+                    'initials' => 'M.',
+                    'suffix' => 'Jr',
                 ]
             ]
         ];


### PR DESCRIPTION
This enables for instance the `Jr.` in 'Tiptree, James Jr.' to be
parsed as a suffix instead of a middle name.

Fixes #18