### PR TITLE
Detect last name prefixes in combined lastname parts (fixes #30)

### DIFF
--- a/src/Name.php
+++ b/src/Name.php
@@ -92,15 +92,7 @@ class Name
      */
     public function getGivenName(): string
     {
-        $fullNameParts = [];
-
-        foreach ($this->parts as $part) {
-            if ($part instanceof GivenNamePart) {
-                $fullNameParts[] = $part->normalize();
-            }
-        }
-
-        return implode(' ', $fullNameParts);
+        return $this->export('GivenNamePart');
     }
 
     /**

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -527,6 +527,13 @@ class ParserTest extends TestCase
                     'lastname' => 'Judy',
                     'salutation' => 'Her Honour Mrs.'
                 ]
+            ],
+            [
+                'Etje Heijdanus-De Boer',
+                [
+                    'firstname' => 'Etje',
+                    'lastname' => 'Heijdanus-De Boer',
+                ]
             ]
         ];
     }


### PR DESCRIPTION
This enables the detection of lastnames combined via a dash with
the prefix to a following lastname, e.g. in "Etje Heijdanus-De Boer".
At this point the entire part is treated as Lastname as there is
no support for re-combining last name parts or prefixes.
This means the 'De' prefix in 'De Boer' above cannot be accessed
individually.