### PR TITLE
letters after apostrophe should not be capitalized

### DIFF
--- a/src/Part/AbstractPart.php
+++ b/src/Part/AbstractPart.php
@@ -70,7 +70,7 @@ abstract class AbstractPart
             return $word;
         }
 
-        return preg_replace_callback('/[\p{L}0-9]+/ui', [$this, 'camelcaseReplace'], $word);
+        return preg_replace_callback('/[\p{L}0-9\i]+/ui', [$this, 'camelcaseReplace'], $word);
     }
 
     /**


### PR DESCRIPTION
The letter after apostrophe should not be capitalised(e.g.  A'a Lee should not be converted to A'A Lee).